### PR TITLE
DATA-3111 Updated datatypes in ads insights schema and removed multiple reach columns

### DIFF
--- a/tap_facebook/schemas/ads_insights.json
+++ b/tap_facebook/schemas/ads_insights.json
@@ -18,7 +18,7 @@
     "clicks": {
       "type": [
         "null",
-        "integer"
+        "string"
       ]
     },
     "date_stop": {
@@ -48,7 +48,7 @@
           "value": {
             "type": [
               "null",
-              "number"
+              "string"
             ]
           },
           "action_destination": {
@@ -260,12 +260,6 @@
       "type": [
         "null",
         "number"
-      ]
-    },
-    "reach": {
-      "type": [
-        "null",
-        "integer"
       ]
     },
     "canvas_avg_view_percent": {


### PR DESCRIPTION
Description:
This PR is for updating the data types in ads insights schema and removing multiple columns.

Changes:
1. Updated property values of clicks and website_ctr columns
2. Removed multiple reach columns

Jira:
https://ryan-miranda.atlassian.net/browse/DATA-3111?atlOrigin=eyJpIjoiYjhlMGVjZTRmODg5NDhmOWIyNzlmMzUzYmUxMmNmYzQiLCJwIjoiaiJ9