### PR TITLE
DATA-31111 Updated adsinsights schema from integer to string for click columns, …

### DIFF
--- a/tap_facebook/schemas/ads_insights.json
+++ b/tap_facebook/schemas/ads_insights.json
@@ -99,13 +99,13 @@
     "canvas_avg_view_time": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "unique_inline_link_clicks": {
       "type": [
         "null",
-        "integer"
+        "string"
       ]
     },
     "cost_per_unique_action_type": {
@@ -137,7 +137,7 @@
     "inline_post_engagement": {
       "type": [
         "null",
-        "integer"
+        "string"
       ]
     },
     "campaign_name": {
@@ -149,7 +149,7 @@
     "inline_link_clicks": {
       "type": [
         "null",
-        "integer"
+        "string"
       ]
     },
     "campaign_id": {
@@ -161,7 +161,7 @@
     "cpc": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "ad_name": {
@@ -173,31 +173,31 @@
     "cost_per_unique_inline_link_click": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "cpm": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "cost_per_inline_post_engagement": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "inline_link_click_ctr": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "cpp": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "cost_per_action_type": {
@@ -229,19 +229,19 @@
     "unique_link_clicks_ctr": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "spend": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "cost_per_unique_click": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "adset_name": {
@@ -253,19 +253,19 @@
     "unique_clicks": {
       "type": [
         "null",
-        "integer"
+        "string"
       ]
     },
     "social_spend": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "canvas_avg_view_percent": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "account_id": {
@@ -308,31 +308,31 @@
     "impressions": {
       "type": [
         "null",
-        "integer"
+        "string"
       ]
     },
     "unique_ctr": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "cost_per_inline_link_click": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "ctr": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "reach": {
       "type": [
         "null",
-        "integer"
+        "string"
       ]
     }
   }


### PR DESCRIPTION
Description:
This PR is for updating the data types in ctr columns, inline columns, impression column, and reach column.

Changes:
1. Updated property values of unique_inline_link_clicks to string
2. Updated property values of inline_post_engagement to string
3. Updated property values of inline_link_clicks to string
4. Updated property values of cpc to string
5. Updated property values of cpm to string
6. Updated property values of inline_link_click_ctr to string
7. Updated property values of cpp to string
8. Updated property values of unique_link_clicks_ctr to string
9. Updated property values of spend to string
10. Updated property values of cost_per_unique_click to string
11. Updated property values of unique_clicks to string
12. Updated property values of social_spend to string
13. Updated property values of canvas_avg_view_percent to string
14. Updated property values of impressions to string
15. Updated property values of unique_ctr to string
16. Updated property values of cost_per_inline_link_click to string
17. Updated property values of ctr to string
18. Updated property values of reach to string

Jira:
https://ryan-miranda.atlassian.net/browse/DATA-3111?atlOrigin=eyJpIjoiYjhlMGVjZTRmODg5NDhmOWIyNzlmMzUzYmUxMmNmYzQiLCJwIjoiaiJ9