### PR TITLE
DATA-3115 Resolve schema exists error

### DIFF
--- a/tap_facebook/client.py
+++ b/tap_facebook/client.py
@@ -89,7 +89,7 @@ class facebookStream(RESTStream):
             A dictionary of URL query parameters.
         """
         params: dict = {}
-        params["limit"] = 250
+        params["limit"] = 25
         if next_page_token is not None:
             params["after"] = next_page_token
         if self.replication_key:

--- a/tap_facebook/schemas/ads_insights.json
+++ b/tap_facebook/schemas/ads_insights.json
@@ -87,7 +87,7 @@
     "frequency": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "account_name": {
@@ -99,13 +99,13 @@
     "canvas_avg_view_time": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "unique_inline_link_clicks": {
       "type": [
         "null",
-        "integer"
+        "string"
       ]
     },
     "cost_per_unique_action_type": {
@@ -137,7 +137,7 @@
     "inline_post_engagement": {
       "type": [
         "null",
-        "integer"
+        "string"
       ]
     },
     "campaign_name": {
@@ -149,7 +149,7 @@
     "inline_link_clicks": {
       "type": [
         "null",
-        "integer"
+        "string"
       ]
     },
     "campaign_id": {
@@ -161,7 +161,7 @@
     "cpc": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "ad_name": {
@@ -173,31 +173,31 @@
     "cost_per_unique_inline_link_click": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "cpm": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "cost_per_inline_post_engagement": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "inline_link_click_ctr": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "cpp": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "cost_per_action_type": {
@@ -229,19 +229,19 @@
     "unique_link_clicks_ctr": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "spend": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "cost_per_unique_click": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "adset_name": {
@@ -253,19 +253,19 @@
     "unique_clicks": {
       "type": [
         "null",
-        "integer"
+        "string"
       ]
     },
     "social_spend": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "canvas_avg_view_percent": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "account_id": {
@@ -308,31 +308,31 @@
     "impressions": {
       "type": [
         "null",
-        "integer"
+        "string"
       ]
     },
     "unique_ctr": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "cost_per_inline_link_click": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "ctr": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "reach": {
       "type": [
         "null",
-        "integer"
+        "string"
       ]
     }
   }

--- a/tap_facebook/schemas/adsets.json
+++ b/tap_facebook/schemas/adsets.json
@@ -38,7 +38,7 @@
     "is_dynamic_creative": {
       "type": [
         "null",
-        "string"
+        "boolean"
       ]
     },
     "learning_stage_info": {
@@ -50,7 +50,7 @@
     "lifetime_imps": {
       "type": [
         "null",
-        "string"
+        "number"
       ]
     },
     "multi_optimization_goal_weight": {
@@ -74,13 +74,13 @@
     "pacing_type": {
       "type": [
         "null",
-        "string"
+        "array"
       ]
     },
     "recurring_budget_semantics": {
       "type": [
         "null",
-        "string"
+        "boolean"
       ]
     },
     "source_adset_id": {
@@ -98,13 +98,13 @@
     "targeting_optimization_types": {
       "type": [
         "null",
-        "string"
+        "array"
       ]
     },
     "use_new_app_click": {
       "type": [
         "null",
-        "string"
+        "boolean"
       ]
     },
     "promoted_object": {
@@ -185,7 +185,7 @@
     "daily_budget": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
       "maximum": 100000000000000000000000000000000,
       "minimum": -100000000000000000000000000000000,
@@ -196,7 +196,7 @@
     "budget_remaining": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
       "maximum": 100000000000000000000000000000000,
       "minimum": -100000000000000000000000000000000,
@@ -233,7 +233,7 @@
     "lifetime_budget": {
       "type": [
         "null",
-        "number"
+        "string"
       ],
       "maximum": 100000000000000000000000000000000,
       "minimum": -100000000000000000000000000000000,
@@ -251,25 +251,25 @@
         "CLICKS": {
           "type": [
             "null",
-            "integer"
+            "string"
           ]
         },
         "ACTIONS": {
           "type": [
             "null",
-            "integer"
+            "string"
           ]
         },
         "IMPRESSIONS": {
           "type": [
             "null",
-            "integer"
+            "string"
           ]
         },
         "REACH": {
           "type": [
             "null",
-            "integer"
+            "string"
           ]
         }
       }

--- a/tap_facebook/schemas/campaigns.json
+++ b/tap_facebook/schemas/campaigns.json
@@ -39,13 +39,13 @@
     "can_create_brand_lift_study": {
       "type": [
         "null",
-        "string"
+        "boolean"
       ]
     },
     "can_use_spend_cap": {
       "type": [
         "null",
-        "string"
+        "boolean"
       ]
     },
     "configured_status": {
@@ -57,13 +57,13 @@
     "has_secondary_skadnetwork_reporting": {
       "type": [
         "null",
-        "string"
+        "boolean"
       ]
     },
     "is_skadnetwork_attribution": {
       "type": [
         "null",
-        "string"
+        "boolean"
       ]
     },
     "primary_attribution": {
@@ -78,7 +78,19 @@
         "string"
       ]
     },
+    "pacing_type": {
+      "type": [
+        "null",
+        "array"
+      ]
+    },
     "source_campaign_id": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "boosted_object_id": {
       "type": [
         "null",
         "string"
@@ -87,7 +99,7 @@
     "special_ad_categories": {
       "type": [
         "null",
-        "string"
+        "array"
       ]
     },
     "special_ad_category": {
@@ -111,13 +123,13 @@
     "spend_cap": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "budget_remaining": {
       "type": [
         "null",
-        "number"
+        "string"
       ]
     },
     "start_time": {

--- a/tap_facebook/streams.py
+++ b/tap_facebook/streams.py
@@ -69,7 +69,7 @@ class adsinsightStream(facebookStream):
 
     name = "adsinsights"
     path = "/insights?level=ad&fields={}".format(columns)
-    primary_keys = ["id"]
+    primary_keys = ["account_id","date_start"]
     schema_filepath = SCHEMAS_DIR / "ads_insights.json"
     tap_stream_id = "adsinsights"
     #replication_key = "created_time"
@@ -81,6 +81,7 @@ class adsStream(facebookStream):
                "adset_id",
                "campaign_id",
                "bid_type",
+               "bid_info",
                "status",
                "updated_time",
                "created_time",
@@ -90,7 +91,8 @@ class adsStream(facebookStream):
                "source_ad_id",
                "creative",
                "tracking_specs",
-               "conversion_specs"]
+               "conversion_specs",
+               "recommendations"]
 
     columns_remaining = ["adlabels", "recommendations"]
 
@@ -191,17 +193,17 @@ class campaignStream(facebookStream):
                "special_ad_category_country",
                "spend_cap",
                "status",
-               "topline_id"]
+               "topline_id",
+               "boosted_object_id",
+               "pacing_type"]
 
     columns_remaining = ["ad_strategy_group_id",
                          "ad_strategy_id",
                          "adlabels",
-                         "boosted_object_id",
                          "daily_budget",
                          "issues_info",
                          "last_budget_toggling_time",
                          "lifetime_budget",
-                         "pacing_type",
                          "recommendations"]
 
     name = "campaigns"


### PR DESCRIPTION
Description:
This is PR is for resolving schema exist error, json decode error, and key format error which we had in facebook sdk.

Changes:
1. Updated meltano.yml file
2. Updated schema for ads insights, adsets, and campaigns
3. Updated the budget columns which were in number to string, category and pacing_type columns to array
4. Added bid_type and recommendations columns to adstream
5. Added boosted_object_id and pacing_type columns to campaigns stream

Jira:
https://ryan-miranda.atlassian.net/browse/DATA-3115?atlOrigin=eyJpIjoiNWQwNzg4NDlmNmIwNGVhNGFlZmYxMjMwYjU0YzViMTQiLCJwIjoiaiJ9


