### PR TITLE
Api Rate Limit Handling

### DIFF
--- a/tap_facebook/client.py
+++ b/tap_facebook/client.py
@@ -13,7 +13,6 @@ from singer_sdk.exceptions import FatalAPIError, RetriableAPIError
 
 import requests, json
 import backoff
-import time
 
 _Auth = Callable[[requests.PreparedRequest], requests.PreparedRequest]
 SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")


### PR DESCRIPTION
This PR adds Rate Limit handling for the Facebook API using a Backoff function.

- Adds the _backoff_on_rate_limit function to backoff from making API requests when a RetriableAPIError is raised. Function uses Jitter to randomize and incrementally increase wait time.