### PR TITLE
fix: use latest api version by default

### DIFF
--- a/tap_facebook/tap.py
+++ b/tap_facebook/tap.py
@@ -56,7 +56,7 @@ class TapFacebook(Tap):
             "api_version",
             th.StringType,
             description="The API version to request data from.",
-            default="v16.0",
+            default="v18.0",
         ),
         th.Property(
             "account_id",

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9,7 +9,6 @@ from tap_facebook.tap import TapFacebook
 
 SAMPLE_CONFIG = {
     "start_date": "2023-03-01T00:00:00Z",
-    "api_version": "v16.0",
     "access_token": os.environ["TAP_FACEBOOK_ACCESS_TOKEN"],
     "account_id": os.environ["TAP_FACEBOOK_ACCOUNT_ID"],
 }


### PR DESCRIPTION
Closes https://github.com/MeltanoLabs/tap-facebook/issues/90