### PR TITLE
ci: Use `hynek/build-and-inspect-python-package`

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,53 +1,42 @@
-name: Publish with Dynamic Versioning
+name: Build
 
-on:
-  release:
-    types: [published]
+on: push
 
 permissions:
-  contents: write
-  id-token: write
+  contents: write # Upload artifacts to release
+  id-token: write # Use PyPI trusted publishing
 
 jobs:
+  build:
+    name: Build and Inspect
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.1
+        with:
+          fetch-depth: 0
+      - uses: hynek/build-and-inspect-python-package@v2
+
   publish:
     name: Publish to PyPI
     runs-on: ubuntu-latest
-    environment: publishing
-    env:
-      PIP_CONSTRAINT: .github/workflows/constraints.txt
+    needs: [build]
+    environment:
+      name: publishing
+      url: https://pypi.org/p/meltano-tap-facebook
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4.0.0
+      - uses: actions/download-artifact@v4.1.1
         with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v4.6.1
-        with:
-          python-version: "3.10"
-
-      - name: Upgrade pip
-        run: |
-          pip install pip
-          pip --version
-
-      - name: Install Poetry
-        run: |
-          pipx install poetry
-          pipx inject poetry poetry-dynamic-versioning[plugin]
-          poetry --version
-          poetry self show plugins
-
-      - name: Build
-        run: poetry build
-
+          name: Packages
+          path: dist
       - name: Upload wheel to release
         uses: svenstaro/upload-release-action@v2
         with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: dist/*.whl
           tag: ${{ github.ref }}
           overwrite: true
           file_glob: true
 
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1.8.10
+        uses: pypa/gh-action-pypi-publish@v1.8.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ multi_line_output = 3 # Vertical Hanging Indent
 src_paths = "tap_facebook"
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
+requires = ["poetry-core==1.8.0", "poetry-dynamic-versioning==1.2.0"]
 build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
Gets rid of a few steps in the release workflow that require Poetry and instead uses the [pypa/build](https://github.com/pypa/build) under the hood to build the sdist and wheel. We get slightly faster builds and a nice summary of the built artifacts:

<img width="1597" alt="Screenshot 2024-01-23 at 11 46 17 a m" src="https://github.com/MeltanoLabs/tap-facebook/assets/16805946/eb1fffc0-c149-4713-85e8-1c37d9456107">

https://github.com/MeltanoLabs/tap-facebook/actions/runs/7629716619?pr=140