### PR TITLE
fix: primary key bug

### DIFF
--- a/tap_facebook/streams/ad_insights.py
+++ b/tap_facebook/streams/ad_insights.py
@@ -63,9 +63,18 @@ class AdsInsightStream(Stream):
         kwargs["name"] = f"{self.name}_{self._report_definition['name']}"
         super().__init__(*args, **kwargs)
 
-    @Stream.primary_keys.getter
+    @property
     def primary_keys(self) -> list[str] | None:
         return ["date_start", "account_id", "ad_id"] + self._report_definition["breakdowns"]
+
+    @primary_keys.setter
+    def primary_keys(self, new_value: list[str] | None) -> None:
+        """Set primary key(s) for the stream.
+
+        Args:
+            new_value: TODO
+        """
+        self._primary_keys = new_value
 
     @staticmethod
     def _get_datatype(field: str) -> th.Type | None:

--- a/tap_facebook/streams/ad_insights.py
+++ b/tap_facebook/streams/ad_insights.py
@@ -63,18 +63,9 @@ class AdsInsightStream(Stream):
         kwargs["name"] = f"{self.name}_{self._report_definition['name']}"
         super().__init__(*args, **kwargs)
 
-    @property
+    @Stream.primary_keys.getter
     def primary_keys(self) -> list[str] | None:
         return ["date_start", "account_id", "ad_id"] + self._report_definition["breakdowns"]
-
-    @primary_keys.setter
-    def primary_keys(self, new_value: list[str] | None) -> None:
-        """Set primary key(s) for the stream.
-
-        Args:
-            new_value: TODO
-        """
-        self._primary_keys = new_value
 
     @staticmethod
     def _get_datatype(field: str) -> th.Type | None:

--- a/tap_facebook/streams/ad_insights.py
+++ b/tap_facebook/streams/ad_insights.py
@@ -67,6 +67,15 @@ class AdsInsightStream(Stream):
     def primary_keys(self) -> list[str] | None:
         return ["date_start", "account_id", "ad_id"] + self._report_definition["breakdowns"]
 
+    @primary_keys.setter
+    def primary_keys(self, new_value: list[str] | None) -> None:
+        """Set primary key(s) for the stream.
+
+        Args:
+            new_value: TODO
+        """
+        self._primary_keys = new_value
+
     @staticmethod
     def _get_datatype(field: str) -> th.Type | None:
         d_type = AdsInsights._field_types[field]  # noqa: SLF001


### PR DESCRIPTION
@edgarrmondragon I just found this bug. When testing without a catalog input it selects all automatically so it worked for me but when a catalog is passed in it takes a different code path and was erroring out since I overrode the primary key property. I would have assumed that it would still access the setter in the base class but that doesnt seem to be true after debugging. This resolves that issue.