### PR TITLE
chore: bump api version to v22.0 and remove deprecated field

### DIFF
--- a/tap_facebook/streams/creative.py
+++ b/tap_facebook/streams/creative.py
@@ -107,7 +107,6 @@ class CreativeStream(FacebookStream):
         Property("dynamic_ad_voice", StringType),
         Property("effective_authorization_category", StringType),
         Property("effective_instagram_media_id", StringType),
-        Property("effective_instagram_story_id", StringType),
         Property("effective_object_story_id", StringType),
         Property("enable_direct_install", BooleanType),
         Property("image_hash", StringType),

--- a/tap_facebook/tap.py
+++ b/tap_facebook/tap.py
@@ -67,7 +67,7 @@ class TapFacebook(Tap):
             "api_version",
             th.StringType,
             description="The API version to request data from.",
-            default="v19.0",
+            default="v22.0",
         ),
         th.Property(
             "account_id",


### PR DESCRIPTION
I only saw one necessary change based on the changelog  https://developers.facebook.com/docs/graph-api/changelog#available-marketing-api-versions%2F