### PR TITLE
fix: Remove problematic fields from `adsinsights` stream

### DIFF
--- a/tap_facebook/streams/ad_insights.py
+++ b/tap_facebook/streams/ad_insights.py
@@ -59,6 +59,9 @@ EXCLUDED_FIELDS = [
     "estimated_ad_recall_rate_upper_bound",
     "estimated_ad_recallers_lower_bound",
     "estimated_ad_recallers_upper_bound",
+    "marketing_messages_media_view_rate",
+    "marketing_messages_phone_call_btn_click_rate",
+    "wish_bid",
 ]
 
 SLEEP_TIME_INCREMENT = 5


### PR DESCRIPTION
Removed fields which seem to be failing as of April 24.

Attempt to resolve #368 