### PR TITLE
fix(ad_insights): exclude marketing_messages_website_purchase_values field

### DIFF
--- a/tap_facebook/streams/ad_insights.py
+++ b/tap_facebook/streams/ad_insights.py
@@ -61,6 +61,7 @@ EXCLUDED_FIELDS = [
     "estimated_ad_recallers_upper_bound",
     "marketing_messages_media_view_rate",
     "marketing_messages_phone_call_btn_click_rate",
+    "marketing_messages_website_purchase_values",
     "wish_bid",
 ]
 


### PR DESCRIPTION
## Summary

- Adds `marketing_messages_website_purchase_values` to `EXCLUDED_FIELDS` in `ad_insights.py`
- Field is rejected by the Facebook Ads Insights API with error code `#100`: `marketing_messages_website_purchase_values is not valid for fields param`
- Follows the same pattern as other already-excluded `marketing_messages_*` fields

## Test plan

- [ ] Run `tap-facebook` with an account that previously triggered the error
- [ ] Confirm sync completes without `#100` API error on `ad_insights` stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)